### PR TITLE
feat: strapi to use same slug on diffrent locales

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,6 @@
         "@strapi/strapi": "4.9.0",
         "mysql": "2.18.1"
       },
-      "devDependencies": {},
       "engines": {
         "node": ">=14.19.1 <=18.x.x",
         "npm": ">=6.0.0"

--- a/backend/public/schema.graphql
+++ b/backend/public/schema.graphql
@@ -58,7 +58,7 @@ type Article {
   locale: String
   localizations(filters: ArticleFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): ArticleRelationResponseCollection
   publishedAt: DateTime
-  slug: String
+  slug: String!
   title: String
   updatedAt: DateTime
 }

--- a/backend/src/api/article/content-types/article/lifecycles.ts
+++ b/backend/src/api/article/content-types/article/lifecycles.ts
@@ -1,0 +1,23 @@
+export default {
+  async beforeUpdate(event) {
+    const { data } = event.params;
+    await validateSlugIsUnique(data.slug);
+  },
+  async beforeCreate(event) {
+    const { data } = event.params;
+    await validateSlugIsUnique(data.slug);
+  },
+};
+
+const validateSlugIsUnique = async (slug: string) => {
+  const entries = (await strapi.entityService.findMany("api::article.article", {
+    fields: ["id", "slug"],
+    filters: {
+      slug: slug,
+    },
+  })) as { id: number; slug: string }[];
+  if (entries.length >= 2) {
+    const { ApplicationError } = require("@strapi/utils").errors;
+    throw new ApplicationError("Slug is duplicated!");
+  }
+};

--- a/backend/src/api/article/content-types/article/lifecycles.ts
+++ b/backend/src/api/article/content-types/article/lifecycles.ts
@@ -5,18 +5,19 @@ export default {
   },
   async beforeCreate(event) {
     const { data } = event.params;
-    await validateSlugIsUnique(data.slug);
+    await validateSlugIsUnique(data.slug, true);
   },
 };
 
-const validateSlugIsUnique = async (slug: string) => {
+const validateSlugIsUnique = async (slug: string, isCreate?: boolean) => {
   const entries = (await strapi.entityService.findMany("api::article.article", {
     fields: ["id", "slug"],
     filters: {
       slug: slug,
     },
   })) as { id: number; slug: string }[];
-  if (entries.length >= 2) {
+  const acceptableLength = isCreate ? 0 : 1;
+  if (entries.length > acceptableLength) {
     const { ApplicationError } = require("@strapi/utils").errors;
     throw new ApplicationError("Slug is duplicated!");
   }

--- a/backend/src/api/article/content-types/article/schema.json
+++ b/backend/src/api/article/content-types/article/schema.json
@@ -33,19 +33,11 @@
         }
       }
     },
-    "slug": {
-      "type": "uid",
-      "targetField": "title"
-    },
     "cover": {
       "type": "media",
       "multiple": false,
       "required": false,
-      "allowedTypes": [
-        "images",
-        "files",
-        "videos"
-      ],
+      "allowedTypes": ["images", "files", "videos"],
       "pluginOptions": {
         "i18n": {
           "localized": true
@@ -65,6 +57,18 @@
         }
       },
       "type": "richtext"
+    },
+    "slug": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "string",
+      "required": true,
+      "unique": false,
+      "regex": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "targetField": "title"
     }
   }
 }

--- a/backend/types/types.d.ts
+++ b/backend/types/types.d.ts
@@ -565,7 +565,7 @@ export interface NexusGenObjects {
     description?: string | null; // String
     locale?: string | null; // String
     publishedAt?: NexusGenScalars['DateTime'] | null; // DateTime
-    slug?: string | null; // String
+    slug: string; // String!
     title?: string | null; // String
     updatedAt?: NexusGenScalars['DateTime'] | null; // DateTime
   }
@@ -776,7 +776,7 @@ export interface NexusGenFieldTypes {
     locale: string | null; // String
     localizations: NexusGenRootTypes['ArticleRelationResponseCollection'] | null; // ArticleRelationResponseCollection
     publishedAt: NexusGenScalars['DateTime'] | null; // DateTime
-    slug: string | null; // String
+    slug: string; // String!
     title: string | null; // String
     updatedAt: NexusGenScalars['DateTime'] | null; // DateTime
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ./backend/config:/opt/app/config
       - ./backend/src:/opt/app/src
       - ./backend/package.json:/opt/package.json
-      - ./backend/local.env:/opt/app/.env
+      - ./backend/env/local.env:/opt/app/.env
       - ./backend/public:/opt/app/public
       - ./backend/types:/opt/app/types
     ports:


### PR DESCRIPTION
**_What will change?_**

- Update `slug` type to `string`.
- Add custom validation to make `slug` unique.
- Now, it's possible to use same slug on diffrent locales.

<!-- If this has a larger context, uncomment and put it here
_Purpose_

Why do we introduce this change? What problem do we solve? What is the
story/background for it?
-->

<!-- # Uncomment if you have any dependencies
**_Dependencies and/or References_**

* Another related PR
* A Confluence page
* External documentation

-->

<!-- # If there is some insights/learnings to share, put them here
**_Learnings_**

-->

<!-- # If there is deployment related information, uncomment and put it here
**_Deployment & Risks_**

* [x] All tests and checks are passing (or any failures are well understood and acceptable)
* [x] This PR is ready to be deployed to production (once successfully merged with the `main` branch)
* [ ] There is a migration necessary for this to work
* [ ] There is a dependent PR that needs to be deployed first
-->

<!-- # Reminders
* [Write good pull requests!](https://seesparkbox.com/foundry/github_pull_requests_for_everyone) 👼
* [Be a good reviewer!](https://seesparkbox.com/foundry/stop_giving_depressing_code_reviews) 🧐
-->
